### PR TITLE
Add rights baseline + policy change process

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Early-stage governance and operations scaffolding.
 - Manifesto / reason for being (`docs/manifesto.md`)
 - Charter draft (`docs/charter.md`)
 - Governance policy set (`docs/governance/`)
+- Rights baseline (draft) (`docs/governance/rights-baseline.md`)
+- Policy change process (draft) (`docs/governance/policy-change-process.md`)
 - Decision log (`docs/decision-log.md`)
 - Transparency reporting policy/templates (`docs/transparency/`)
 - Roadmap phases and milestones (`docs/roadmap/`)

--- a/docs/governance/policy-change-process.md
+++ b/docs/governance/policy-change-process.md
@@ -1,0 +1,53 @@
+# Policy Change Process (Draft v1)
+
+This document defines how governance/policy rules in this repository are proposed, discussed, approved, recorded, and adopted.
+
+It exists to satisfy the manifesto commitment to transparent rule changes (“in writing”).
+
+This is a governance policy draft and is not legal advice.
+
+## Scope
+
+Applies to governance and policy documents in this repo, including:
+
+- `docs/**`
+- Repo-root governance docs (`README.md`, `GOVERNANCE.md`, etc.)
+
+## Definitions
+
+- **Editorial change**: typos, formatting, or clarifications that do not change meaning or behavior.
+- **Policy change**: any change that affects rights, obligations, decision rules, moderation, finances, transparency, or operational expectations.
+- **Emergency change**: a time-sensitive policy change where delay creates material safety/security/financial risk.
+
+## Default workflow (policy changes)
+
+1. **Propose**: open an issue using the `Policy proposal` template (`.github/ISSUE_TEMPLATE/policy_proposal.yml`).
+2. **Discuss**:
+   - Minor/iterative changes: keep the issue open for comment for at least 72 hours.
+   - Significant changes: use an RFC-style issue and allow at least 7 days for comment (see `CONTRIBUTING.md`).
+3. **Decide**: admins vote per `docs/governance/roles-and-voting.md` (quorum of at least 2 active admins).
+4. **Record**: log the accepted decision in `docs/decision-log.md` with:
+   - date + decision ID
+   - summary and decision text
+   - approvers (and recusals, if any)
+   - links to the issue + PR
+   - follow-ups/owners
+5. **Adopt**: merge the PR. Default effective date is the merge timestamp unless the decision specifies otherwise.
+6. **Review**: for significant changes, include a revisit date or review trigger (e.g., “after 90 days” or “after first incident”).
+
+## Editorial changes
+
+- May be merged via PR with at least one admin approval.
+- Do not require a decision log entry unless they also resolve an open governance decision.
+
+## Emergency changes
+
+- Require explicit 2-admin signoff in the issue or PR thread.
+- Must be timeboxed when possible (e.g., “temporary until <date>”).
+- Must have a retrospective decision log entry within 7 days describing why emergency handling was required.
+
+## Transparency requirements
+
+- Every policy PR links to the proposal issue.
+- Every adopted policy change has a decision log entry linking back to both the issue and PR.
+- When details cannot be public, publish a redacted summary with rationale (never “trust us”).

--- a/docs/governance/rights-baseline.md
+++ b/docs/governance/rights-baseline.md
@@ -1,0 +1,58 @@
+# Rights Baseline (Draft v1)
+
+This document translates the project manifesto (`docs/manifesto.md`) into concrete governance commitments and implementation targets.
+
+This is a governance policy draft and is not legal advice.
+
+## Scope
+
+Applies to Open World Collective-operated project spaces (e.g., official servers, community channels, and org-managed infrastructure) and to the governance rules in this repository.
+
+## Baseline rights
+
+### Due process before exile
+
+- “Exile” includes permanent bans/removals from official project spaces and revocation of project participation rights.
+- Default posture: no permanent exile without a recorded action rationale and an appeal path.
+- Emergency safety actions (temporary) may be taken immediately, but must be documented promptly with rationale and duration.
+- Canonical process draft: `docs/policies/moderation-and-appeals.md`.
+
+### Transparent rule changes
+
+- Policy and rule changes happen in public, via issues and PRs in this repository.
+- Changes must be linkable, reviewable, and time-stamped (issue + PR + decision log entry when adopted).
+- Canonical process draft: `docs/governance/policy-change-process.md`.
+
+### Meaningful appeals
+
+- Appeals must be possible for significant moderation actions.
+- Reviews should be performed by at least two admins who were not directly involved in the original action.
+- When full details cannot be public for safety/privacy, publish a redacted summary and rationale.
+- Canonical process draft: `docs/policies/moderation-and-appeals.md`.
+
+### Portable identity
+
+- Identity should not be designed as a trap: participants should be able to export their identity data from official systems in a documented format.
+- If portability is not yet implemented for a given system, the limitation and planned path must be documented.
+
+### Portable assets
+
+- Participants should be able to export assets they have rights to (their own creations and any explicitly portable assets) in documented formats where technically feasible.
+- If portability is constrained by platform or security realities, document the constraint and the mitigation plan.
+
+### Creator ownership and respect
+
+- Default posture: creators retain IP ownership of their work.
+- Any licenses required for contribution, distribution, or operation must be explicit, written down, and narrowly scoped to the project’s needs (no “trust us” capture clauses).
+
+## Evidence and recordkeeping
+
+The project should be able to point to a public paper trail that these rights are real:
+
+- Policy changes: linked issues/PRs and (when adopted) `docs/decision-log.md` entries.
+- Moderation actions: action records + appeal outcomes per `docs/policies/moderation-and-appeals.md`.
+- Transparency: monthly reports per `docs/transparency/reporting-cadence.md` and templates under `docs/transparency/`.
+
+## Review cadence
+
+Revisit this baseline at least quarterly (or after any major incident) and propose amendments via the standard policy change process.

--- a/docs/governance/roles-and-voting.md
+++ b/docs/governance/roles-and-voting.md
@@ -28,3 +28,4 @@
 
 - All accepted decisions are logged in `docs/decision-log.md`.
 - Entries include approvers, recusals, and follow-up actions.
+- Policy updates follow `docs/governance/policy-change-process.md`.


### PR DESCRIPTION
Adds two draft governance docs that translate the manifesto into enforceable, auditable practice:

- `docs/governance/rights-baseline.md`: due process, transparent rule changes, meaningful appeals, portability, creator ownership.
- `docs/governance/policy-change-process.md`: how policy changes are proposed, discussed, voted, recorded, and adopted.

Also links these from `docs/governance/roles-and-voting.md` and `README.md`.

Not legal advice.

Refs #1 #7
