### PR TITLE
Add conflict-of-interest policy

### DIFF
--- a/.github/workflows/conflict-of-interest-policy-check.yml
+++ b/.github/workflows/conflict-of-interest-policy-check.yml
@@ -1,0 +1,16 @@
+name: Conflict of Interest Policy Check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check-conflict-of-interest-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Verify conflict-of-interest policy files
+        run: bash scripts/check_conflict_of_interest_policy.sh
+      - name: Run policy check script tests
+        run: bash tests/test_check_conflict_of_interest_policy.sh

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -18,6 +18,12 @@
 - Any fund movement or budget approval requires 2-admin signoff documented in a public issue or decision log entry.
 - Public ledger records are treated as canonical financial references.
 
+## Conflicts and recusals
+
+- Canonical policy: `docs/governance/conflict-of-interest.md`.
+- Conflicted admins must disclose and recuse from the affected decision.
+- Requestors, payees, and direct participants in an incident under review do not count as required approvers or appeal reviewers.
+
 ## Transparency
 
 - Governance decisions are recorded in `docs/decision-log.md`.

--- a/docs/governance/conflict-of-interest.md
+++ b/docs/governance/conflict-of-interest.md
@@ -1,0 +1,87 @@
+# Conflict of Interest and Recusal (Draft v1)
+
+This policy defines the baseline conflict-of-interest standard for governance, financial approvals, and appeals in this repository.
+
+This is a governance policy draft and is not legal advice.
+
+## Scope
+
+Applies to admins and any other person acting as a reviewer, approver, or decision-maker in Open World Collective governance processes.
+
+## Goals
+
+- Reduce governance capture risk.
+- Make decisions easier to trust and audit.
+- Set a practical bootstrap baseline without requiring over-disclosure of private details.
+
+## Baseline standard
+
+A conflict exists when a reasonable person would question whether someone can act impartially on a specific decision.
+
+Conflicts include, at minimum:
+
+- direct financial interest in the outcome
+- being the requestor, payee, or likely beneficiary of a financial decision
+- close personal, romantic, familial, or household relationship with an affected party
+- employment, contractor, vendor, or customer relationship with an affected party
+- direct prior involvement in the incident or decision under review
+- any other circumstance likely to compromise independent judgment
+
+## Options considered
+
+- Financial-only conflicts: too narrow for moderation, hiring, vendor, and governance decisions.
+- Disclosure without recusal: too easy to abuse in a small bootstrap group.
+- Blanket exclusion from all related discussion: too rigid for small-team operations.
+
+Bootstrap choice: disclose conflicts early, allow factual background when needed, but require recusal from approval and final decision-making.
+
+## Disclosure rules
+
+- Disclose known conflicts before substantive discussion, recommendation, approval, or vote.
+- If a conflict is discovered later, disclose it promptly in the same issue, PR, or decision thread.
+- Public records should disclose the existence and general type of conflict. Do not publish unnecessary private details.
+
+Examples of acceptable public disclosure:
+
+- `financial conflict; recused`
+- `prior involvement in incident; recused from appeal review`
+- `close relationship with affected party; recused`
+
+## Recusal rules
+
+When conflicted, the person must:
+
+- not cast a deciding vote
+- not count toward required approval minimums or quorum for that decision
+- not act as the sole reviewer or approver
+
+They may still:
+
+- provide factual background if requested by the uninvolved reviewers
+- answer clarifying questions about timeline or context
+
+They may not:
+
+- write the final approval determination
+- review an appeal of their own moderation action
+- self-approve reimbursements, payments, contracts, or other benefits to themselves
+
+## Substitute approver rules
+
+- Use another uninvolved admin whenever possible.
+- For financial approvals, the requestor and payee cannot serve as required approvers.
+- For moderation appeals, reviewers must be admins not directly involved in the original action.
+- If recusals make quorum impossible, defer the decision until enough uninvolved reviewers are available.
+- If delay creates material safety, security, or financial risk, temporary emergency action may proceed under the relevant policy, followed by retrospective review and recordkeeping.
+
+## Recordkeeping
+
+- Issues and PRs should note disclosed conflicts and recusals in the discussion thread.
+- Accepted decisions logged in `docs/decision-log.md` should list approvers and any recusals.
+- Financial approvals should link the disclosed conflict/recusal note when relevant.
+
+## If a conflict is discovered after a decision
+
+- Record the late-discovered conflict in the relevant issue or PR.
+- Re-evaluate whether the decision should be confirmed, amended, or reopened by uninvolved reviewers.
+- Note the outcome in the decision log if the original decision was already recorded there.

--- a/docs/governance/fund-approval.md
+++ b/docs/governance/fund-approval.md
@@ -18,6 +18,7 @@ Before spending, create a public issue with:
 
 - Minimum 2-admin signoff is required.
 - No self-approval: requestor cannot be the only approving admin.
+- Conflicts and recusals follow `docs/governance/conflict-of-interest.md`.
 - Approval comments must be explicit (`Approved`) and linked from the decision log.
 
 ## Execution and reporting

--- a/docs/governance/roles-and-voting.md
+++ b/docs/governance/roles-and-voting.md
@@ -21,7 +21,8 @@
 
 ## Conflict of interest
 
-- Any admin with direct personal or financial conflict must disclose and recuse from that vote.
+- Canonical policy: `docs/governance/conflict-of-interest.md`.
+- Any admin with a conflict must disclose it and recuse from that decision.
 - Recusal is recorded in the decision log entry.
 
 ## Recordkeeping

--- a/scripts/check_conflict_of_interest_policy.sh
+++ b/scripts/check_conflict_of_interest_policy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${ROOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+cd "${ROOT}"
+
+POLICY_PATH="docs/governance/conflict-of-interest.md"
+
+test -f "${POLICY_PATH}"
+grep -F "Canonical policy: \`docs/governance/conflict-of-interest.md\`." GOVERNANCE.md >/dev/null
+grep -F "Canonical policy: \`docs/governance/conflict-of-interest.md\`." docs/governance/roles-and-voting.md >/dev/null
+grep -F "Conflicts and recusals follow \`docs/governance/conflict-of-interest.md\`." docs/governance/fund-approval.md >/dev/null
+grep -F "A conflict exists when a reasonable person would question whether someone can act impartially on a specific decision." "${POLICY_PATH}" >/dev/null
+grep -F -- "- Disclose known conflicts before substantive discussion, recommendation, approval, or vote." "${POLICY_PATH}" >/dev/null
+grep -F -- "- Use another uninvolved admin whenever possible." "${POLICY_PATH}" >/dev/null
+
+echo "Conflict-of-interest policy check passed."

--- a/tests/test_check_conflict_of_interest_policy.sh
+++ b/tests/test_check_conflict_of_interest_policy.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CHECK_SCRIPT="${REPO_ROOT}/scripts/check_conflict_of_interest_policy.sh"
+
+assert_fails() {
+  if "$@"; then
+    echo "expected failure but command succeeded: $*" >&2
+    exit 1
+  fi
+}
+
+mk_case_dir() {
+  mktemp -d "${TMPDIR:-/tmp}/gov-conflict-policy-test.XXXXXX"
+}
+
+write_valid_case() {
+  local dir="$1"
+  mkdir -p "${dir}/docs/governance"
+  cat >"${dir}/GOVERNANCE.md" <<'EOF'
+# Governance
+
+## Conflicts and recusals
+
+- Canonical policy: `docs/governance/conflict-of-interest.md`.
+EOF
+  cat >"${dir}/docs/governance/roles-and-voting.md" <<'EOF'
+# Roles and Voting (v1)
+
+## Conflict of interest
+
+- Canonical policy: `docs/governance/conflict-of-interest.md`.
+EOF
+  cat >"${dir}/docs/governance/fund-approval.md" <<'EOF'
+# Fund Approval Policy (v1)
+
+## Approval rule
+
+- Conflicts and recusals follow `docs/governance/conflict-of-interest.md`.
+EOF
+  cat >"${dir}/docs/governance/conflict-of-interest.md" <<'EOF'
+# Conflict of Interest and Recusal (Draft v1)
+
+A conflict exists when a reasonable person would question whether someone can act impartially on a specific decision.
+
+- Disclose known conflicts before substantive discussion, recommendation, approval, or vote.
+- Use another uninvolved admin whenever possible.
+EOF
+}
+
+main() {
+  local d1 d2 d3
+
+  d1="$(mk_case_dir)"
+  write_valid_case "${d1}"
+  ROOT_DIR="${d1}" bash "${CHECK_SCRIPT}"
+
+  d2="$(mk_case_dir)"
+  write_valid_case "${d2}"
+  rm -f "${d2}/docs/governance/conflict-of-interest.md"
+  assert_fails env ROOT_DIR="${d2}" bash "${CHECK_SCRIPT}"
+
+  d3="$(mk_case_dir)"
+  write_valid_case "${d3}"
+  sed -i '' 's/Use another uninvolved admin whenever possible./Use any admin./' "${d3}/docs/governance/conflict-of-interest.md" 2>/dev/null || \
+    sed -i 's/Use another uninvolved admin whenever possible./Use any admin./' "${d3}/docs/governance/conflict-of-interest.md"
+  assert_fails env ROOT_DIR="${d3}" bash "${CHECK_SCRIPT}"
+
+  rm -rf "${d1}" "${d2}" "${d3}"
+  echo "check_conflict_of_interest_policy tests passed."
+}
+
+main "$@"


### PR DESCRIPTION
Adds a bootstrap conflict-of-interest baseline under `docs/governance/conflict-of-interest.md` and wires it into the canonical governance docs.

This covers:
- conflict definitions
- disclosure timing and format
- recusal rules
- substitute approver rules
- recordkeeping for late-discovered conflicts

Also adds a repo-native check, test, and workflow so the policy wiring stays intact.

Validation run locally:
- `bash scripts/check_conflict_of_interest_policy.sh`
- `bash tests/test_check_conflict_of_interest_policy.sh`
- `bash tests/test_check_ai_provider_policy.sh`

Refs #8